### PR TITLE
chore: upgrade Lambda runtime to Node.js 20.x

### DIFF
--- a/backend/serverless.yml
+++ b/backend/serverless.yml
@@ -4,7 +4,7 @@ frameworkVersion: '4'
 
 provider:
   name: aws
-  runtime: nodejs18.x
+  runtime: nodejs20.x
   region: eu-west-1
   stage: dev
   environment:


### PR DESCRIPTION
This PR is closed because the runtime bump was already merged into develop. We’ll include it in the next release from develop to main