### PR TITLE
Separate YouTube API keys per environment (#37)

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,14 +40,15 @@ cd backend
 npm install
 npm run offline
 
-# Deployment
-npx serverless deploy
+# Deployment Backend (AWS Stages & SSM)
+npx serverless deploy --stage dev
+npx serverless deploy --stage prod
 
 # Debug Logging
 DEBUG=true npx serverless invoke local --function generateCitation --path event.json
 ```
 
-> You'll need a YouTube Data API key stored in AWS SSM Parameter Store at /citematic/youtubeApiKey.
+> You'll need a YouTube Data API key per environement stored in AWS SSM Parameter Store at /citematic/youtubeApiKey-<stage>.
 
 ---
 

--- a/backend/serverless.yml
+++ b/backend/serverless.yml
@@ -6,9 +6,9 @@ provider:
   name: aws
   runtime: nodejs20.x
   region: eu-west-1
-  stage: dev
+  stage: ${opt:stage, 'dev'}
   environment:
-    YOUTUBE_API_KEY: ${env:YOUTUBE_API_KEY, ssm:/citematic/youtubeApiKey}
+    YOUTUBE_API_KEY: ${env:YOUTUBE_API_KEY, ssm:/citematic/youtubeApiKey-${self:provider.stage}}
     DEBUG: ${env:DEBUG, 'false'}
 
 functions:

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,1 @@
+NEXT_PUBLIC_API_URL=http://localhost:3001/dev


### PR DESCRIPTION
## Overview

This PR implements support for separate YouTube Data API keys per environment (development, production, and CI) to ensure no cross-leakage of credentials.

## Changes

- **serverless.yml**  
  - Reads `YOUTUBE_API_KEY` first from a local `.env` (for the CI only), then falls back to AWS SSM Parameter Store at `/citematic/youtubeApiKey-<stage>`.
- **GitHub Actions**  
  - CI jobs now pull `YOUTUBE_API_KEY` from the `YOUTUBE_API_KEY` repository secret for both unit tests and `serverless offline`.
- **README.md**  
  - Expanded **Environment Configuration** section with step-by-step setup for AWS SSM parameters and CI secrets.

## Testing

1. **Local**: `npx serverless offline --stage dev` fetches the correct key from SSM.  
2. **AWS Deploy**: `npx serverless deploy --stage dev|prod` fetches the correct key from SSM.  
3. **CI**: GitHub Actions runs pass with `YOUTUBE_API_KEY`.  
