### PR TITLE
chore(release): 1.1.2 – AWS runtime & YouTube API keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,14 +40,15 @@ cd backend
 npm install
 npm run offline
 
-# Deployment
-npx serverless deploy
+# Deployment Backend (AWS Stages & SSM)
+npx serverless deploy --stage dev
+npx serverless deploy --stage prod
 
 # Debug Logging
 DEBUG=true npx serverless invoke local --function generateCitation --path event.json
 ```
 
-> You'll need a YouTube Data API key stored in AWS SSM Parameter Store at /citematic/youtubeApiKey.
+> You'll need a YouTube Data API key per environement stored in AWS SSM Parameter Store at /citematic/youtubeApiKey-<stage>.
 
 ---
 

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "1.0.0",
+  "version": "1.1.2",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/backend/serverless.yml
+++ b/backend/serverless.yml
@@ -6,9 +6,9 @@ provider:
   name: aws
   runtime: nodejs20.x
   region: eu-west-1
-  stage: dev
+  stage: ${opt:stage, 'dev'}
   environment:
-    YOUTUBE_API_KEY: ${env:YOUTUBE_API_KEY, ssm:/citematic/youtubeApiKey}
+    YOUTUBE_API_KEY: ${env:YOUTUBE_API_KEY, ssm:/citematic/youtubeApiKey-${self:provider.stage}}
     DEBUG: ${env:DEBUG, 'false'}
 
 functions:

--- a/backend/serverless.yml
+++ b/backend/serverless.yml
@@ -4,7 +4,7 @@ frameworkVersion: '4'
 
 provider:
   name: aws
-  runtime: nodejs18.x
+  runtime: nodejs20.x
   region: eu-west-1
   stage: dev
   environment:

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,1 @@
+NEXT_PUBLIC_API_URL=http://localhost:3001/dev


### PR DESCRIPTION
## Release 1.1.2 – Interim Release

### Overview
This PR backports and ships two critical updates on `develop` into `main` for an interim patch release:
- 🚨 **Migrate AWS Lambda Runtime** from Node.js 18.x to Node.js 20.x (closes #39)  
- 🔐 **Support separate YouTube API keys** per environment (dev, prod, CI) (closes #37)  

### Changes
- **Backend**  
  - Updated AWS Lambda runtime to `nodejs20.x` in `serverless.yml`  
  - Refactored environment variable resolution to load `YOUTUBE_API_KEY` from CI secret or SSM fallback  
- **Docs & Config**  
  - Bumped version in `package.json` to `1.1.2` 

### Testing
1. **Local**  
   ```bash
   git checkout release/v1.1.2
   npm ci && npm test
   npx serverless offline --stage dev
